### PR TITLE
Added multi-arch support

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -51,6 +51,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
@@ -75,6 +81,7 @@ jobs:
           push: false
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ matrix.tags }}
+          platforms: linux/amd64,linux/arm64
 
       - name: Run Anchore vulnerability scanner
         uses: anchore/scan-action@v3

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,7 +12,7 @@ name: Build & Publish
 on:
   push:
     # Pattern matched against refs/tags
-    tags:        
+    tags:
       - '**'
 
 env:
@@ -58,6 +58,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Log in to the Container registry
         uses: docker/login-action@0d4c9c5ea7693da7b068278f7b52bda2a190a446
         with:
@@ -82,6 +88,7 @@ jobs:
           push: true
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ matrix.tags }}
+          platforms: linux/amd64,linux/arm64
 
       - name: Run Anchore vulnerability scanner
         uses: anchore/scan-action@v3


### PR DESCRIPTION
Builds the bitcoin-core image with both `linux/amd64` and `linux/arm64` architectures. Should be able to run natively on RaspberryPi and Apple M3 chip hardware.

Resolves #5 